### PR TITLE
Catch SSL handshake exceptions

### DIFF
--- a/smartsheet/smartsheet.py
+++ b/smartsheet/smartsheet.py
@@ -206,6 +206,8 @@ class Smartsheet(object):
             stream = True
         try:
             res = self._session.send(prepped_request, stream=stream)
+        except requests.exceptions.SSLError as rex:
+            raise HttpError(rex, 'SSL handshake error, old CA bundle or old OpenSSL?')
         except (requests.exceptions.RequestException) as rex:
             raise UnexpectedRequestError(rex.request, rex.response)
 


### PR DESCRIPTION
SSL handshake errors were being masked with an unexpected request exception. Spent a couple of hours trying to figure out what the heck was going on. 

This is actually triggered by an old Python (more specifically an old OpenSSL module) in OSX distributions. It might be good to put a note in the README as to this problem for anyone else attempting to use the SDK with OSX. The easiest solution to fix is to install python from Homebrew.