### PR TITLE
clarified add_user function description

### DIFF
--- a/smartsheet/users.py
+++ b/smartsheet/users.py
@@ -96,7 +96,7 @@ class Users(object):
 
                 resourceViewer (optional)
 
-                send_email (bool): Either true or false to indicate whether or not to notify the user by email. Default
+            send_email (bool): Either true or false to indicate whether or not to notify the user by email. Default
                 is false.
 
         Returns:


### PR DESCRIPTION
clarification of `add_user` function description in smartsheet/users.py.
`send_email` is not a key in the `user_obj`. It is an argument of `add_user` function.

As the [documentation](http://smartsheet-platform.github.io/api-docs/?python#add-user) does not provide a detailed explanation of how to actuate sendEmail parameter in Python API, merging this PR will help anyone looking into the source to use sendEmail parameter.