### PR TITLE
Fix Typo (rows_ids ==> row_ids)

### DIFF
--- a/smartsheet/models/sent_update_request.py
+++ b/smartsheet/models/sent_update_request.py
@@ -76,10 +76,10 @@ class SentUpdateRequest(object):
                 self.sent_by = props['sent_by']
             if 'status' in props:
                 self.status = props['status']
-            if 'rowsIds' in props:
-                self.rows_ids = props['rowIds']
-            if 'rows_ids' in props:
-                self.rows_ids = props['row_ids']
+            if 'rowIds' in props:
+                self.row_ids = props['rowIds']
+            if 'row_ids' in props:
+                self.row_ids = props['row_ids']
             if 'columnIds' in props:
                 self.column_ids = props['columnIds']
             if 'column_ids' in props:


### PR DESCRIPTION
get_sent_update_request returns an empty list for rowIds where a direct API call returns the correct list of rows. I posit this is because of the typo in sent_update_request.