### PR TITLE
Add mock API serialization tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,8 @@ smartsheet/version.py
 .cache/*
 .pytest_cache/*
 
+# ignore VSCode files
+.vscode/*
+
 # ignore ugly batch files
 *.bat

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
             'pytest-instafail'
         ]
     },
-    tests_require=['pytest', 'parameterized'],
+    tests_require=['pytest'],
     cmdclass={
         'test': PyTest
     }

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,11 @@ setup(
     include_package_data=True,
     long_description=open('README.rst').read(),
     extras_require={
-        'test': ['coverage', 'coveralls', 'pytest'],
+        'test': [
+            'coverage',
+            'coveralls',
+            'pytest'
+        ],
         'develop': [
             'coverage',
             'coveralls[yaml]',
@@ -74,7 +78,7 @@ setup(
             'pytest-instafail'
         ]
     },
-    tests_require=['pytest'],
+    tests_require=['pytest', 'parameterized'],
     cmdclass={
         'test': PyTest
     }

--- a/smartsheet/models/attachment.py
+++ b/smartsheet/models/attachment.py
@@ -38,6 +38,7 @@ class Attachment(object):
         self._attachment_type = EnumeratedValue(AttachmentType)
         self._created_at = Timestamp()
         self._created_by = TypedObject(User)
+        self._description = String()
         self._id_ = Number()
         self._mime_type = String()
         self._name = String()
@@ -97,6 +98,14 @@ class Attachment(object):
     @created_by.setter
     def created_by(self, value):
         self._created_by.value = value
+    
+    @property
+    def description(self):
+        return self._description.value
+    
+    @description.setter
+    def description(self, value):
+        self._description.value = value
 
     @property
     def id_(self):

--- a/smartsheet/sheets.py
+++ b/smartsheet/sheets.py
@@ -943,8 +943,9 @@ class Sheets(object):
         _op = fresh_operation('share_sheet')
         _op['method'] = 'POST'
         _op['path'] = '/sheets/' + str(sheet_id) + '/shares'
-        _op['query_params']['sendEmail'] = send_email
         _op['json'] = share_obj
+        if send_email:
+            _op['query_params']['sendEmail'] = 'true'
 
         expected = ['Result', 'Share']
 

--- a/smartsheet/sheets.py
+++ b/smartsheet/sheets.py
@@ -36,26 +36,21 @@ class Sheets(object):
         self._base = smartsheet_obj
         self._log = logging.getLogger(__name__)
 
-    def add_columns(self, sheet_id, list_of_columns):
+    def add_columns(self, sheet_id, column_or_list_of_columns):
         """Insert one or more Columns into the specified Sheet
 
         Args:
             sheet_id (int): Sheet ID
-            list_of_columns (list[Column]): One or more
-                Column objects.
+            column_or_list_of_columns (Column | list[Column]): One or more Column objects
 
         Returns:
             Result
         """
-        if isinstance(list_of_columns, (dict, Column)):
-            arg_value = list_of_columns
-            list_of_columns = TypedList(Column)
-            list_of_columns.append(arg_value)
 
         _op = fresh_operation('add_columns')
         _op['method'] = 'POST'
         _op['path'] = '/sheets/' + str(sheet_id) + '/columns'
-        _op['json'] = list_of_columns
+        _op['json'] = column_or_list_of_columns
 
         expected = ['Result', 'Column']
 

--- a/smartsheet/sheets.py
+++ b/smartsheet/sheets.py
@@ -59,7 +59,7 @@ class Sheets(object):
 
         return response
 
-    def add_rows(self, sheet_id, row_or_list_of_rows, include=None, allow_partial_success=False):
+    def add_rows(self, sheet_id, row_or_list_of_rows, include=None):
         """Insert one or more Rows into the specified Sheet.
 
         If multiple rows are specified in the request, all rows
@@ -99,10 +99,6 @@ class Sheets(object):
 
                    hyperlink (optional)
             include (list[str]): A comma-separated list of row elements to include
-            allow_partial_success (bool, optional): If not provided or set to False, bulk additions
-                will fail if any of the rows to be added encounter a failure.  If set to True, this
-                allows partial success of bulk additions, with each row succeeding or failing
-                independently
 
         Returns:
             Result
@@ -113,10 +109,8 @@ class Sheets(object):
         _op['json'] = row_or_list_of_rows
         if include is not None:
             _op['query_params']['include'] = include
-        if allow_partial_success:
-            _op['query_params']['allowPartialSuccess'] = 'true'
 
-        expected = ['BulkItemResult', 'Row'] if allow_partial_success else ['Result', 'Row']
+        expected = ['Result', 'Row']
 
         prepped_request = self._base.prepare_request(_op)
         response = self._base.request(prepped_request, expected, _op)

--- a/smartsheet/sheets.py
+++ b/smartsheet/sheets.py
@@ -17,12 +17,12 @@
 
 from __future__ import absolute_import
 
-from .models.column import Column
-from .models.row import Row
-from .types import TypedList
 import logging
 import os.path
 from datetime import datetime
+from .models.column import Column
+from .models.row import Row
+from .types import TypedList
 from .util import deprecated
 from . import fresh_operation
 
@@ -209,8 +209,9 @@ class Sheets(object):
         _op['method'] = 'POST'
         _op['path'] = '/sheets/' + str(sheet_id) + '/rows/copy'
         _op['query_params']['include'] = include
-        _op['query_params']['ignoreRowsNotFound'] = ignore_rows_not_found
         _op['json'] = copy_or_move_row_directive_obj
+        if ignore_rows_not_found:
+            _op['query_params']['ignoreRowsNotFound'] = ignore_rows_not_found
 
         expected = 'CopyOrMoveRowResult'
         prepped_request = self._base.prepare_request(_op)
@@ -757,8 +758,9 @@ class Sheets(object):
         _op['method'] = 'POST'
         _op['path'] = '/sheets/' + str(sheet_id) + '/rows/move'
         _op['query_params']['include'] = include
-        _op['query_params']['ignoreRowsNotFound'] = ignore_rows_not_found
         _op['json'] = copy_or_move_row_directive_obj
+        if ignore_rows_not_found:
+            _op['query_params']['ignoreRowsNotFound'] = ignore_rows_not_found
 
         expected = 'CopyOrMoveRowResult'
         prepped_request = self._base.prepare_request(_op)

--- a/smartsheet/types.py
+++ b/smartsheet/types.py
@@ -132,7 +132,7 @@ class TypedObject(object):
         elif hasattr(value, 'is_explicit_null'):
             self._value = value
         else:
-            raise ValueError("`{0}` invalid type for [1] value".format(value, self.object_type))
+            raise ValueError("`{0}` invalid type for {1} value".format(value, self.object_type))
 
     def __str(self):
         return json.dumps(self._value)

--- a/smartsheet/types.py
+++ b/smartsheet/types.py
@@ -132,7 +132,7 @@ class TypedObject(object):
         elif hasattr(value, 'is_explicit_null'):
             self._value = value
         else:
-            raise ValueError("`[0]` invalid type for [1] value".format(value, self.object_type))
+            raise ValueError("`{0}` invalid type for [1] value".format(value, self.object_type))
 
     def __str(self):
         return json.dumps(self._value)
@@ -156,7 +156,7 @@ class Number(object):
         elif isinstance(value, (six.integer_types, float)):
             self._value = value
         else:
-            raise ValueError("`[0]` invalid type for Number value".format(value))
+            raise ValueError("`{0}` invalid type for Number value".format(value))
 
     def __str__(self):
         return str(self.value)
@@ -187,7 +187,7 @@ class String(object):
                         value, self.accept))
             self._value = value
         else:
-            raise ValueError("`[0]` invalid type for String value".format(value))
+            raise ValueError("`{0}` invalid type for String value".format(value))
 
     @property
     def accept(self):
@@ -200,7 +200,7 @@ class String(object):
         elif isinstance(value, six.string_types):
             self._accept = [value]
         else:
-            raise ValueError("`[0]` invalid type for accept".format(value))
+            raise ValueError("`{0}` invalid type for accept".format(value))
 
     def __str__(self):
         return self._value
@@ -224,7 +224,7 @@ class Boolean(object):
         elif isinstance(value, bool):
             self._value = value
         else:
-            raise ValueError("`[0]` invalid type for Boolean value".format(value))
+            raise ValueError("`{0}` invalid type for Boolean value".format(value))
 
     def __str__(self):
         return str(self._value)
@@ -251,7 +251,7 @@ class Timestamp(object):
             value = parse(value)
             self._value = value
         else:
-            raise ValueError("`[0]` invalid type for Timestamp value".format(value))
+            raise ValueError("`{0}` invalid type for Timestamp value".format(value))
 
     def __str__(self):
         return str(self._value)

--- a/smartsheet/users.py
+++ b/smartsheet/users.py
@@ -102,8 +102,9 @@ class Users(object):
         _op = fresh_operation('add_user')
         _op['method'] = 'POST'
         _op['path'] = '/users'
-        _op['query_params']['sendEmail'] = send_email
         _op['json'] = user_obj
+        if send_email:
+            _op['query_params']['sendEmail'] = send_email
 
         expected = ['Result', 'User']
 

--- a/tests/mock_api/test_mock_api_columns.py
+++ b/tests/mock_api/test_mock_api_columns.py
@@ -1,68 +1,48 @@
 # pylint: disable=C0103,W0232
 
-from parameterized import parameterized, param
 from smartsheet.models import Column
 from mock_api_test_helper import MockApiTestHelper, clean_api_error
 
 class TestMockApiColumns(MockApiTestHelper):
-    @parameterized([
-        param(
-            scenario='Update Column - Change Type - Picklist',
-            get_method=lambda client: client.Sheets.update_column,
-            params=[
-                123,
-                234,
-                Column({
-                    'index': 2,
-                    'title': 'Updated Column',
-                    'type': 'PICKLIST',
-                    'options': [
-                        'An',
-                        'updated',
-                        'column'
-                    ],
-                    'width': 200
-                })
-            ],
-            get_validation_field=lambda response: response.result.title,
-            expected_validation_val='Updated Column'
-        ),
-        param(
-            scenario='Update Column - Change Type - Contact List',
-            get_method=lambda client: client.Sheets.update_column,
-            params=[
-                123,
-                234,
-                Column({
-                    "index": 2,
-                    "title": "Updated Column",
-                    "type": "CONTACT_LIST",
-                    "contactOptions": [
-                        {
-                            "name": "Some Contact",
-                            "email": "some.contact@smartsheet.com"
-                        },
-                        {
-                            "name": "Some Other Contact",
-                            "email": "some.other.contact@smartsheet.com"
-                        }
-                    ],
-                    "width": 200
-                })
-            ],
-            get_validation_field=lambda response: response.result.title,
-            expected_validation_val='Updated Column'
-        )
-    ])
     @clean_api_error
-    def test_successful(
-            self,
-            scenario,
-            get_method,
-            params,
-            get_validation_field,
-            expected_validation_val):
+    def test_column_type_change_to_picklist(self):
 
-        self.client.as_test_scenario(scenario)
-        response = get_method(self.client)(*params)
-        assert get_validation_field(response) == expected_validation_val
+        self.client.as_test_scenario('Update Column - Change Type - Picklist')
+
+        response = self.client.Sheets.update_column(123, 234, Column({
+            'index': 2,
+            'title': 'Updated Column',
+            'type': 'PICKLIST',
+            'options': [
+                'An',
+                'updated',
+                'column'
+            ],
+            'width': 200
+        }))
+
+        assert response.result.title == 'Updated Column'
+
+    @clean_api_error
+    def test_column_type_change_to_contact_list(self):
+
+        self.client.as_test_scenario('Update Column - Change Type - Contact List')
+
+        response = self.client.Sheets.update_column(123, 234, Column({
+            'index': 2,
+            'title': 'Updated Column',
+            'type': 'CONTACT_LIST',
+            'contactOptions': [
+                {
+                    'name': 'Some Contact',
+                    'email': 'some.contact@smartsheet.com'
+                },
+                {
+                    'name': 'Some Other Contact',
+                    'email': 'some.other.contact@smartsheet.com'
+                }
+            ],
+            'width': 200
+        }))
+
+        assert response.result.title == 'Updated Column'

--- a/tests/mock_api/test_mock_api_columns.py
+++ b/tests/mock_api/test_mock_api_columns.py
@@ -1,0 +1,68 @@
+# pylint: disable=C0103,W0232
+
+from parameterized import parameterized, param
+from smartsheet.models import Column
+from mock_api_test_helper import MockApiTestHelper, clean_api_error
+
+class TestMockApiColumns(MockApiTestHelper):
+    @parameterized([
+        param(
+            scenario='Update Column - Change Type - Picklist',
+            get_method=lambda client: client.Sheets.update_column,
+            params=[
+                123,
+                234,
+                Column({
+                    'index': 2,
+                    'title': 'Updated Column',
+                    'type': 'PICKLIST',
+                    'options': [
+                        'An',
+                        'updated',
+                        'column'
+                    ],
+                    'width': 200
+                })
+            ],
+            get_validation_field=lambda response: response.result.title,
+            expected_validation_val='Updated Column'
+        ),
+        param(
+            scenario='Update Column - Change Type - Contact List',
+            get_method=lambda client: client.Sheets.update_column,
+            params=[
+                123,
+                234,
+                Column({
+                    "index": 2,
+                    "title": "Updated Column",
+                    "type": "CONTACT_LIST",
+                    "contactOptions": [
+                        {
+                            "name": "Some Contact",
+                            "email": "some.contact@smartsheet.com"
+                        },
+                        {
+                            "name": "Some Other Contact",
+                            "email": "some.other.contact@smartsheet.com"
+                        }
+                    ],
+                    "width": 200
+                })
+            ],
+            get_validation_field=lambda response: response.result.title,
+            expected_validation_val='Updated Column'
+        )
+    ])
+    @clean_api_error
+    def test_successful(
+            self,
+            scenario,
+            get_method,
+            params,
+            get_validation_field,
+            expected_validation_val):
+
+        self.client.as_test_scenario(scenario)
+        response = get_method(self.client)(*params)
+        assert get_validation_field(response) == expected_validation_val

--- a/tests/mock_api/test_mock_api_rows.py
+++ b/tests/mock_api/test_mock_api_rows.py
@@ -638,3 +638,35 @@ class TestMockApiRows(MockApiTestHelper):
         response = self.client.Sheets.update_rows(1, [first_row])
 
         assert response.result[0].row_number == 100
+
+    @clean_api_error
+    def test_move_row_to_another_sheet(self):
+        self.client.as_test_scenario('Move row to another sheet')
+
+        result = self.client.Sheets.move_rows(
+            1228520367122308,
+            self.client.models.CopyOrMoveRowDirective({
+                'row_ids': [1765250516182916],
+                'to': self.client.models.CopyOrMoveRowDestination({
+                    'sheet_id': 799249123305348
+                })
+            })
+        )
+
+        assert result.destination_sheet_id == 799249123305348
+
+    @clean_api_error
+    def test_copy_row_to_another_sheet(self):
+        self.client.as_test_scenario('Copy row to another sheet')
+
+        result = self.client.Sheets.copy_rows(
+            1228520367122308,
+            self.client.models.CopyOrMoveRowDirective({
+                'row_ids': [2891150423025540],
+                'to': self.client.models.CopyOrMoveRowDestination({
+                    'sheet_id': 799249123305348
+                })
+            })
+        )
+
+        assert result.destination_sheet_id == 799249123305348

--- a/tests/mock_api/test_mock_api_rows.py
+++ b/tests/mock_api/test_mock_api_rows.py
@@ -526,6 +526,33 @@ class TestMockApiRows(MockApiTestHelper):
         assert response.result[0].cells[1].display_value == "2FS +2d 4h"
 
     @clean_api_error
+    def test_add_rows_assign_object_value_predecessor_list_using_float_duration(self):
+        self.client.as_test_scenario(
+            'Add Rows - Assign Object Value - Predecessor List (using floats)')
+
+        lag = Duration({
+            'objectType': 'DURATION',
+            'days': 2.5
+        })
+
+        predecessor_list = PredecessorList()
+        predecessor_list.predecessors.append({
+            'rowId': 10,
+            'type': 'FS',
+            'lag': lag
+        })
+
+        row = Row()
+        row.cells.append({
+            'columnId': 101,
+            'objectValue': predecessor_list
+        })
+
+        response = self.client.Sheets.add_rows(1, [row])
+
+        assert response.result[0].cells[1].display_value == '2FS +2.5d'
+
+    @clean_api_error
     def test_update_rows_clear_value_text_number(self):
         self.client.as_test_scenario('Update Rows - Clear Value - Text Number')
 
@@ -592,6 +619,22 @@ class TestMockApiRows(MockApiTestHelper):
         assert response.result[0].cells[0].column_id == 101
         assert response.result[0].cells[0].value is None
         assert response.result[0].cells[0].link_in_from_cell is None
+
+    @clean_api_error
+    def test_update_rows_clear_value_predecessor_list(self):
+        self.client.as_test_scenario('Update Rows - Clear Value - Predecessor List')
+
+        row = Row()
+        row.id = 10
+        row.cells.append({
+            'columnId': 123,
+            'value': ExplicitNull()
+        })
+
+        response = self.client.Sheets.update_rows(1, [row])
+
+        assert response.result[0].cells[0].column_id == 123
+        assert response.result[0].cells[0].value is None
 
     @clean_api_error
     def test_update_rows_invalid_assign_hyperlink_and_cell_link(self):

--- a/tests/mock_api/test_mock_serialization.py
+++ b/tests/mock_api/test_mock_serialization.py
@@ -279,7 +279,7 @@ class TestMockSerialization(MockApiTestHelper):
             'value': 'Some Value'
         })
 
-        response = self.client.Sheets.add_rows(1, [row1, row2], allow_partial_success=True)
+        response = self.client.Sheets.add_rows_with_partial_success(1, [row1, row2])
 
         assert response.result[0].cells[0].value == 'Some Value'
         assert response.failed_items[0].error.error_code == 1036

--- a/tests/mock_api/test_mock_serialization.py
+++ b/tests/mock_api/test_mock_serialization.py
@@ -1,0 +1,553 @@
+# pylint: disable=C0103,W0232
+
+import pytest
+from smartsheet.models import (
+    AlternateEmail, Attachment, Column, Comment, ContainerDestination, CrossSheetReference,
+    Discussion, ExplicitNull, Favorite, FormatDetails, Group, ImageUrl, MultiRowEmail, Recipient,
+    Row, Schedule, Share, Sheet, SheetEmail, UpdateRequest, User, Workspace
+)
+# from smartsheet.exceptions import ApiError
+from smartsheet.models.object_value import DURATION
+
+from mock_api_test_helper import MockApiTestHelper, clean_api_error
+
+class TestMockSerialization(MockApiTestHelper):
+    @clean_api_error
+    def test_attachment_serialization(self):
+        self.client.as_test_scenario('Serialization - Attachment')
+
+        url_spec = Attachment({
+            'name': 'Search Engine',
+            'description': 'A popular search engine',
+            'attachmentType': 'LINK',
+            'url': 'http://www.google.com'
+        })
+
+        response = self.client.Attachments.attach_url_to_sheet(1, url_spec)
+
+        assert response.result.id == 2
+
+    @clean_api_error
+    def test_home_deserialization(self):
+        self.client.as_test_scenario('Serialization - Home')
+
+        home = self.client.Home.list_all_contents()
+
+        assert home.sheets[0].name == 'editor share sheet'
+        assert home.folders[0].name == 'empty folder'
+        assert home.reports[0].name == 'admin report'
+        assert home.sights[0].name == 'sight'
+        assert home.workspaces[0].name == 'workspace'
+        assert home.workspaces[0].sheets[0].name == 'workspace sheet'
+        assert home.workspaces[0].folders[0].name == 'workspace folder'
+        assert home.workspaces[0].folders[0].sheets[0].name == 'workspace folder sheet'
+        assert home.workspaces[0].folders[0].folders[0].name == 'workspace folder folder'
+        assert (home.workspaces[0].folders[0].folders[0].sheets[0].name
+                == 'workspace folder folder sheet')
+
+    @clean_api_error
+    def test_group_serialization(self):
+        self.client.as_test_scenario('Serialization - Groups')
+
+        response = self.client.Groups.create_group(
+            Group({
+                'name': 'mock api test group',
+                'description': "it's a group",
+                'members': [
+                    {
+                        'email': 'john.doe@smartsheet.com'
+                    },
+                    {
+                        'email': 'jane.doe@smartsheet.com'
+                    }
+                ]
+            })
+        )
+
+        assert response.result.members[0].email == 'john.doe@smartsheet.com'
+
+    @clean_api_error
+    def test_discussion_serialization(self):
+        self.client.as_test_scenario('Serialization - Discussion')
+
+        response = self.client.Discussions.create_discussion_on_row(
+            1,
+            2,
+            Discussion({
+                'comment': Comment({
+                    'text': 'This is a comment!'
+                })
+            })
+        )
+
+        assert response.result.comments[0].created_by.email == 'john.doe@smartsheet.com'
+
+    @clean_api_error
+    def test_contact_serialization(self):
+        self.client.as_test_scenario('Serialization - Contact')
+
+        contact = self.client.Contacts.get_contact('ABC')
+
+        assert contact.email == 'john.doe@smartsheet.com'
+
+    @clean_api_error
+    def test_folder_serialization(self):
+        self.client.as_test_scenario('Serialization - Folder')
+
+        response = self.client.Home.create_folder('folder')
+
+        assert response.result.name == 'folder'
+
+    @clean_api_error
+    def test_column_serialization(self):
+        self.client.as_test_scenario('Serialization - Column')
+
+        column = Column({
+            'title': 'A Brave New Column',
+            'type': 'PICKLIST',
+            'options': [
+                'option1',
+                'option2',
+                'option3'
+            ],
+            'index': 2,
+            'validation': False,
+            'width': 42,
+            'locked': False
+        })
+
+        response = self.client.Sheets.add_columns(1, column)
+
+        assert response.result.title == 'A Brave New Column'
+
+    @clean_api_error
+    def test_user_profile_serialization(self):
+        self.client.as_test_scenario('Serialization - UserProfile')
+
+        user_profile = self.client.Users.get_current_user()
+
+        assert user_profile.account.name == 'john.doe@smartsheet.com'
+
+    @clean_api_error
+    def test_workspace_serialization(self):
+        self.client.as_test_scenario('Serialization - Workspace')
+
+        response = self.client.Workspaces.create_workspace(
+            Workspace({
+                'name': 'A Whole New Workspace'
+            })
+        )
+
+        assert response.result.name == 'A Whole New Workspace'
+
+    @clean_api_error
+    def test_user_serialization(self):
+        self.client.as_test_scenario('Serialization - User')
+
+        response = self.client.Users.add_user(
+            User({
+                'email': 'john.doe@smartsheet.com',
+                'admin': False,
+                'licensedSheetCreator': True,
+                'firstName': 'John',
+                'lastName': 'Doe',
+                'groupAdmin': False,
+                'resourceViewer': True
+            })
+        )
+
+        assert response.result.profile_image.image_id == 'abc'
+
+    @clean_api_error
+    def test_sheet_serialization(self):
+        self.client.as_test_scenario('Serialization - Sheet')
+
+        response = self.client.Home.create_sheet(
+            Sheet({
+                'name': 'The First Sheet',
+                'columns': [
+                    {
+                        'title': 'The First Column',
+                        'primary': True,
+                        'type': 'TEXT_NUMBER'
+                    },
+                    {
+                        'title': 'The Second Column',
+                        'primary': False,
+                        'type': 'TEXT_NUMBER',
+                        'systemColumnType': 'AUTO_NUMBER',
+                        'autoNumberFormat': {
+                            'prefix': '{YYYY}-{MM}-{DD}-',
+                            'suffix': '-SUFFIX',
+                            'fill': '000000'
+                        }
+                    }
+                ]
+            })
+        )
+
+        assert response.result.columns[0].id == 2
+        assert response.result.columns[1].auto_number_format.suffix == '-SUFFIX'
+
+    @clean_api_error
+    def test_alternate_email_serialization(self):
+        self.client.as_test_scenario('Serialization - AlternateEmail')
+
+        alt_email = AlternateEmail({
+            'email': 'not.not.john.doe@smartsheet.com'
+        })
+
+        response = self.client.Users.add_alternate_email(1, [alt_email])
+
+        assert response.result[0].email == 'not.not.john.doe@smartsheet.com'
+
+    @clean_api_error
+    def test_predecessor_serialization(self):
+        self.client.as_test_scenario('Serialization - Predecessor')
+
+        row = Row()
+        row.cells.append({
+            'columnId': 2,
+            'objectValue': {
+                'objectType': 'PREDECESSOR_LIST',
+                'predecessors': [
+                    {
+                        'rowId': 3,
+                        'type': 'FS',
+                        'lag': {
+                            'objectType': 'DURATION',
+                            'negative': False,
+                            'elapsed': False,
+                            'weeks': 1.5,
+                            'days': 2.5,
+                            'hours': 3.5,
+                            'minutes': 4.5,
+                            'seconds': 5.5,
+                            'milliseconds': 6
+                        }
+                    }
+                ]
+            }
+        })
+
+        response = self.client.Sheets.add_rows(1, row, include=['objectValue'])
+
+        assert response.result.cells[4].object_value.predecessors[0].lag.object_type == DURATION
+
+    @clean_api_error
+    def test_index_result_serialization(self):
+        self.client.as_test_scenario('Serialization - IndexResult')
+
+        response = self.client.Users.list_users()
+
+        assert response.data[0].email == 'john.doe@smartsheet.com'
+
+    @clean_api_error
+    def test_image_serialization(self):
+        self.client.as_test_scenario('Serialization - Image')
+
+        row = self.client.Sheets.get_row(1, 2)
+
+        assert row.cells[0].image.alt_text == 'puppy.jpg'
+
+    @clean_api_error
+    def test_image_urls_serialization(self):
+        self.client.as_test_scenario('Serialization - Image Urls')
+
+        response = self.client.Images.get_image_urls(ImageUrl({
+            'imageId': 'abc',
+            'height': 100,
+            'width': 200
+        }))
+
+        assert response.image_urls[0].image_id == 'abc'
+
+    @clean_api_error
+    def test_bulk_failure_serialization(self):
+        self.client.as_test_scenario('Serialization - BulkFailure')
+
+        row1 = Row()
+        row1.to_bottom = True
+        row1.cells.append({
+            'columnId': 2,
+            'value': 'Some Value'
+        })
+
+        row2 = Row()
+        row2.to_bottom = True
+        row2.cells.append({
+            'columnId': 3,
+            'value': 'Some Value'
+        })
+
+        response = self.client.Sheets.add_rows(1, [row1, row2], allow_partial_success=True)
+
+        assert response.result[0].cells[0].value == 'Some Value'
+        assert response.failed_items[0].error.error_code == 1036
+
+    @clean_api_error
+    def test_rows_serialization(self):
+        self.client.as_test_scenario('Serialization - Rows')
+
+        row = Row()
+        row.expanded = True
+        row.format_ = ',,,,,,,,4,,,,,,,'
+        row.locked = False
+        row.cells.append({
+            'columnId': 2,
+            'value': 'url link',
+            'strict': False,
+            'hyperlink': {
+                'url': 'https://google.com'
+            }
+        })
+        row.cells.append({
+            'columnId': 3,
+            'value': 'sheet id link',
+            'strict': False,
+            'hyperlink': {
+                'sheetId': 4
+            }
+        })
+        row.cells.append({
+            'columnId': 5,
+            'value': 'report id link',
+            'strict': False,
+            'hyperlink': {
+                'reportId': 6
+            }
+        })
+
+        response = self.client.Sheets.add_rows(1, row)
+
+        cells = response.result.cells
+
+        assert cells[0].hyperlink.url == 'https://google.com'
+        assert cells[1].hyperlink.sheet_id == 4
+        assert cells[2].hyperlink.report_id == 6
+
+    @clean_api_error
+    def test_cell_link_serialization(self):
+        self.client.as_test_scenario('Serialization - Cell Link')
+
+        updated_row = Row()
+        updated_row.id = 2
+        updated_row.cells.append({
+            'columnId': 3,
+            'value': ExplicitNull(),
+            'linkInFromCell': {
+                'sheetId': 4,
+                'rowId': 5,
+                'columnId': 6
+            }
+        })
+
+        self.client.Sheets.update_rows(1, updated_row)
+
+    @clean_api_error
+    def test_favorite_serialization(self):
+        self.client.as_test_scenario('Serialization - Favorite')
+
+        response = self.client.Favorites.add_favorites(Favorite({
+            'type': 'sheet',
+            'objectId': 1
+        }))
+
+        assert response.result.type == 'sheet'
+
+    @clean_api_error
+    def test_report_serialization(self):
+        self.client.as_test_scenario('Serialization - Report')
+
+        report = self.client.Reports.get_report(1)
+
+        assert report.effective_attachment_options[0] == 'GOOGLE_DRIVE'
+        assert report.columns[0].virtual_id == 2
+        assert report.rows[0].cells[0].virtual_column_id == 2
+
+    @clean_api_error
+    def test_share_serialization(self):
+        self.client.as_test_scenario('Serialization - Share')
+
+        share = Share({
+            'email': 'john.doe@smartsheet.com',
+            'accessLevel': 'VIEWER',
+            'subject': 'Check out this sheet',
+            'message': 'Let me know what you think. Thanks!',
+            'ccMe': True
+        })
+
+        response = self.client.Sheets.share_sheet(1, share, send_email=True)
+
+        assert response.result.id == 'abc'
+
+    @clean_api_error
+    def test_send_via_email_serialization(self):
+        self.client.as_test_scenario('Serialization - Send via Email')
+
+        response = self.client.Sheets.send_sheet(1, SheetEmail({
+            'send_to': [
+                Recipient({
+                    'email': 'john.doe@smartsheet.com'
+                }),
+                Recipient({
+                    'groupId': 2
+                })
+            ],
+            'subject': 'Some subject',
+            'message': 'Some message',
+            'ccMe': True,
+            'format': 'PDF',
+            'formatDetails': FormatDetails({
+                'paperSize': 'LETTER'
+            })
+        }))
+
+        assert response.message == 'SUCCESS'
+
+    @clean_api_error
+    def test_row_email_serialization(self):
+        self.client.as_test_scenario('Serialization - Row Email')
+
+        response = self.client.Sheets.send_rows(1, MultiRowEmail({
+            'send_to': [Recipient({
+                'groupId': 2
+            })],
+            'subject': 'Some subject',
+            'message': 'Some message',
+            'includeAttachments': False,
+            'includeDiscussions': True,
+            'layout': 'VERTICAL',
+            'rowIds': [
+                4
+            ],
+            'columnIds': [
+                3
+            ]
+        }))
+
+        assert response.message == 'SUCCESS'
+
+    @clean_api_error
+    def test_template_serialization(self):
+        self.client.as_test_scenario('Serialization - Template')
+
+        templates = self.client.Templates.list_public_templates()
+
+        assert templates.data[0].categories[0] == 'Featured Templates'
+
+    @clean_api_error
+    def test_update_request_serialization(self):
+        pytest.skip('Date serialization is not easily configurable currently')
+
+        self.client.as_test_scenario('Serialization - Update Request')
+
+        update_request = UpdateRequest({
+            'sendTo': [
+                Recipient({
+                    'email': 'john.doe@smartsheet.com'
+                })
+            ],
+            'rowIds': [
+                2
+            ],
+            'columnIds': [
+                3
+            ],
+            'includeAttachments': True,
+            'includeDiscussions': False,
+            'subject': 'Some subject',
+            'message': 'Some message',
+            'ccMe': True,
+            'schedule': Schedule({
+                'type': 'MONTHLY',
+                'startAt': '2018-03-01T19:00:00Z',
+                'endAt': '2018-06-01T00:00:00Z',
+                'dayOrdinal': 'FIRST',
+                'dayDescriptors': [
+                    'FRIDAY'
+                ],
+                'repeatEvery': 1
+            })
+        })
+
+        response = self.client.Sheets.send_update_request(1, update_request)
+
+        result = response.result
+
+        assert result.send_to[0].email == 'john.doe@smartsheet.com'
+        assert result.column_ids[0] == 3
+        assert result.row_ids[0] == 2
+        assert result.sent_by.name == 'Jane Doe'
+        assert result.schedule.day_descriptors[0] == 'FRIDAY'
+
+    @clean_api_error
+    def test_sent_update_request_serialization(self):
+        self.client.as_test_scenario('Serialization - Sent Update Requests')
+
+        sent_update_request = self.client.Sheets.get_sent_update_request(1, 2)
+
+        assert sent_update_request.sent_by.name == 'Jane Doe'
+        assert sent_update_request.sent_to.email == 'john.doe@smartsheet.com'
+        assert sent_update_request.row_ids[0] == 4
+        assert sent_update_request.column_ids[0] == 5
+
+    @clean_api_error
+    def test_sheet_settings_serialization(self):
+        pytest.skip('Date serialization is not easily configurable currently')
+
+        self.client.as_test_scenario('Serialization - Sheet Settings')
+
+        response = self.client.Sheets.update_sheet(1, Sheet({
+            'userSettings': {
+                'criticalPathEnabled': True,
+                'displaySummaryTasks': True
+            },
+            'projectSettings': {
+                'workingDays': [
+                    'MONDAY',
+                    'TUESDAY'
+                ],
+                'nonWorkingDays': [
+                    '2018-04-04',
+                    '2018-05-05',
+                    '2018-06-06'
+                ],
+                'lengthOfDay': 23.5
+            }
+        }))
+
+        result = response.result
+
+        assert result.user_settings.critical_path_enabled
+        assert result.project_settings.working_days[0] == 'MONDAY'
+        assert result.project_settings.non_working_days[0] == '2018-04-04'
+
+    @clean_api_error
+    def test_container_destination_serialization(self):
+        pytest.skip('Models currently have no concept of a nullable / optional type')
+
+        self.client.as_test_scenario('Serialization - Container Destination')
+
+        response = self.client.Folders.copy_folder(1, ContainerDestination({
+            'destinationType': 'home',
+            'destinationId': ExplicitNull(),
+            'newName': 'Copy of Some Folder'
+        }))
+
+        assert response.result.id == 2
+
+    @clean_api_error
+    def test_cross_sheet_reference_serialization(self):
+        self.client.as_test_scenario('Serialization - Cross Sheet Reference')
+
+        response = self.client.Sheets.create_cross_sheet_reference(1, CrossSheetReference({
+            'name': 'Some Cross Sheet Reference',
+            'sourceSheetId': 2,
+            'startRowId': 3,
+            'endRowId': 4,
+            'startColumnId': 5,
+            'endColumnId': 6
+        }))
+
+        assert response.result.name == 'Some Cross Sheet Reference'

--- a/tests/mock_api/test_mock_serialization.py
+++ b/tests/mock_api/test_mock_serialization.py
@@ -6,7 +6,6 @@ from smartsheet.models import (
     Discussion, ExplicitNull, Favorite, FormatDetails, Group, ImageUrl, MultiRowEmail, Recipient,
     Row, Schedule, Share, Sheet, SheetEmail, UpdateRequest, User, Workspace
 )
-# from smartsheet.exceptions import ApiError
 from smartsheet.models.object_value import DURATION
 
 from mock_api_test_helper import MockApiTestHelper, clean_api_error


### PR DESCRIPTION
This implements the serialization tests scenarios added to the mock API.

A set of bugs in the baseline behaviour were found and fixed where possible; there are likely similar fixes that will need to be made in endpoints not touched by the serialization tests.

Unimplemented:
- Container destination serialization: this takes a container ID that can either be a number or explicitly null; however the SDK currently doesn't seem to have a good way to represent that, and thus cannot pass this test.
- Sheet settings and update request serialization: these tests require date formatting that matches what is specified in the API docs; however, there is no reasonable way to configure that formatting at the moment.  This should be looked into later.