### PR TITLE
Skip Changing Mock API Tests

### DIFF
--- a/tests/mock_api/test_mock_serialization.py
+++ b/tests/mock_api/test_mock_serialization.py
@@ -99,8 +99,7 @@ class TestMockSerialization(MockApiTestHelper):
 
     @clean_api_error
     def test_column_serialization(self):
-        pytest.skip('skipping we do not currently support single entry serialization (always a list)')
-
+        pytest.skip('Skipping until mock API test is updated')
         self.client.as_test_scenario('Serialization - Column')
 
         column = Column({
@@ -204,7 +203,7 @@ class TestMockSerialization(MockApiTestHelper):
 
     @clean_api_error
     def test_predecessor_serialization(self):
-        pytest.skip('include is not a part of add_rows - fix test')
+        pytest.skip('Skipping until mock API test is updated')
         self.client.as_test_scenario('Serialization - Predecessor')
 
         row = Row()
@@ -289,7 +288,7 @@ class TestMockSerialization(MockApiTestHelper):
 
     @clean_api_error
     def test_rows_serialization(self):
-        pytest.skip('skipping we do not currently support single entry serialization (always a list)')
+        pytest.skip('Skipping until mock API test is updated')
         self.client.as_test_scenario('Serialization - Rows')
 
         row = Row()
@@ -331,6 +330,7 @@ class TestMockSerialization(MockApiTestHelper):
 
     @clean_api_error
     def test_cell_link_serialization(self):
+        pytest.skip('Skipping until mock API test is updated')
         self.client.as_test_scenario('Serialization - Cell Link')
 
         updated_row = Row()
@@ -349,6 +349,7 @@ class TestMockSerialization(MockApiTestHelper):
 
     @clean_api_error
     def test_favorite_serialization(self):
+        pytest.skip('Skipping until mock API test is updated')
         self.client.as_test_scenario('Serialization - Favorite')
 
         response = self.client.Favorites.add_favorites(Favorite({
@@ -370,6 +371,7 @@ class TestMockSerialization(MockApiTestHelper):
 
     @clean_api_error
     def test_share_serialization(self):
+        pytest.skip('Skipping until mock API test is updated')
         self.client.as_test_scenario('Serialization - Share')
 
         share = Share({
@@ -528,6 +530,7 @@ class TestMockSerialization(MockApiTestHelper):
 
     @clean_api_error
     def test_container_destination_serialization(self):
+        pytest.skip('Skipping until mock API test is updated')
         pytest.skip('Models currently have no concept of a nullable / optional type')
 
         self.client.as_test_scenario('Serialization - Container Destination')


### PR DESCRIPTION
We will be updating some of the mock API tests to better match the format used by the statically typed languages. To avoid breaking the tests in the time between when the mock API is updated and the SDK's tests are updated, we are temporarily skipping the tests that will be changing.
