### PR TITLE
Remove requirement of enum34 if python version is above 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,12 @@ REQUIRES = [
     'requests-toolbelt',
     'six >= 1.9',
     'certifi',
-    'python-dateutil',
-    'enum34'
+    'python-dateutil'
 ]
+
+if sys.version_info < (3, 4):
+    REQUIRES.append('enum34')
+
 # test packages:
 # https://github.com/coagulant/coveralls-python
 # https://github.com/pytest-dev/pytest


### PR DESCRIPTION
Addresses #122 

enum34 is a package that should only be used for below python 3.4, as enum was introduced as stdlib in 3.4. Including it above 3.4 causes some issues that are described more at length in the issue linked.