### PR TITLE
Make INFO+ level logging return either strings or well-formed json

### DIFF
--- a/smartsheet/smartsheet.py
+++ b/smartsheet/smartsheet.py
@@ -260,7 +260,7 @@ class Smartsheet(object):
             response (Response):
         """
         # request
-        self._log.info('Request: {\ncommand: %s %s\n}', response.request.method, response.request.url)
+        self._log.info('{"request": {"command": "%s %s"}}', response.request.method, response.request.url)
         if response.request.body is not None:
             body_dumps = '<< {} content type suppressed >>'.format(response.request.headers['Content-Type'])
             if is_multipart(response.request):
@@ -273,7 +273,7 @@ class Smartsheet(object):
         content_dumps = '<< {} content type suppressed >>'.format(response.headers['Content-Type'])
         if 'application/json' in response.headers['Content-Type']:
             content = response.content.decode('utf8')
-            content_dumps = json.dumps(json.loads(content), indent=4, sort_keys=True)
+            content_dumps = json.dumps(json.loads(content), sort_keys=True)
         if 200 <= response.status_code <= 299:
             if operation['dl_path'] is None:
                 self._log.debug('Response: {\nstatus: %d %s\ncontent: {\n%s\n}',
@@ -282,7 +282,7 @@ class Smartsheet(object):
                 self._log.debug('Response: {\nstatus: %d %s',
                                 response.status_code, response.reason)
         else:
-            self._log.error('Response: {\nstatus: %d %s\ncontent: {\n%s\n}',
+            self._log.error('{"response": {"statusCode": %d, "reason": "%s", "content": %s}}',
                             response.status_code, response.reason, content_dumps)
 
     def _request(self, prepped_request, operation):


### PR DESCRIPTION
Logs for CloudWatch, Kibana, etc should be nicely parsable. In this MR, logging INFO or higher (INFO, WARN, ERROR) is modified to output either a single string (no newlines) or well-formed json.