### PR TITLE
Update EnumeratedValue __eq__ method to handle comparisons to NoneType

### DIFF
--- a/smartsheet/types.py
+++ b/smartsheet/types.py
@@ -283,6 +283,8 @@ class EnumeratedValue(object):
     def __eq__(self, other):
         if isinstance(other, Enum):
             return self._value == other
+        elif other is None:
+            return self._value == other
         elif isinstance(other, six.string_types):
             return self._value == self.__enum[other]
         NotImplemented

--- a/smartsheet/types.py
+++ b/smartsheet/types.py
@@ -281,9 +281,7 @@ class EnumeratedValue(object):
             self._value = None
 
     def __eq__(self, other):
-        if isinstance(other, Enum):
-            return self._value == other
-        elif other is None:
+        if isinstance(other, Enum) or other is None:
             return self._value == other
         elif isinstance(other, six.string_types):
             return self._value == self.__enum[other]


### PR DESCRIPTION
I've updated the EnumeratedValue class to handle checks for whether something is None. I feel it's more intuitive to (for example) check that `column.system_column_type is None`, as currently I am working around this by doing `str(column.system_column_type) == "None"`