### PR TITLE
Add 'level' parameter to get_row

### DIFF
--- a/smartsheet/sheets.py
+++ b/smartsheet/sheets.py
@@ -420,7 +420,7 @@ class Sheets(object):
 
         return response
 
-    def get_row(self, sheet_id, row_id, include=None, exclude=None):
+    def get_row(self, sheet_id, row_id, include=None, exclude=None, level=None):
         """Get the specified Row of the specified Sheet.
 
         Args:
@@ -433,6 +433,12 @@ class Sheets(object):
                 rowPermalink, rowWriterInfo.
             exclude (str): Response will not include cells
                 that have never contained any data.
+            level (int): Indicates compatibility level of data to return.
+                Valid options: 0, 1, 2
+                Option Descriptors:
+                    0 - Backwards compatible text format
+                    1 - multi-contact complex object
+                    2 - multi-picklist complex object
 
         Returns:
             Row
@@ -442,6 +448,7 @@ class Sheets(object):
         _op['path'] = '/sheets/' + str(sheet_id) + '/rows/' + str(row_id)
         _op['query_params']['include'] = include
         _op['query_params']['exclude'] = exclude
+        _op['query_params']['level'] = level
 
         expected = 'Row'
         prepped_request = self._base.prepare_request(_op)


### PR DESCRIPTION
Added the 'level' parameter to the sheets get_row function to align this with the capabilities described in the 'Get Row' documentation:
https://smartsheet-platform.github.io/api-docs/?python#get-row