### PR TITLE
Support include=publishedFormContainers

### DIFF
--- a/smartsheet/models/sheet.py
+++ b/smartsheet/models/sheet.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import
 from .attachment import Attachment
 from .column import Column
 from .sheet_filter import SheetFilter
+from .sheet_form import SheetForm
 from .comment import Comment
 from .contact_object_value import ContactObjectValue
 from .cross_sheet_reference import CrossSheetReference
@@ -61,6 +62,7 @@ class Sheet(object):
         self._effective_attachment_options = EnumeratedList(AttachmentType)
         self._favorite = Boolean()
         self._filters = TypedList(SheetFilter)
+        self._forms = TypedList(SheetForm)
         self._from_id = Number()
         self._gantt_enabled = Boolean()
         self._has_summary_fields = Boolean()
@@ -189,6 +191,14 @@ class Sheet(object):
     @filters.setter
     def filters(self, value):
         self._filters.load(value)
+
+    @property
+    def forms(self):
+        return self._forms
+    
+    @forms.setter
+    def forms(self, value):
+        self._forms.load(value)
 
     @property
     def from_id(self):

--- a/smartsheet/models/sheet_form.py
+++ b/smartsheet/models/sheet_form.py
@@ -17,7 +17,6 @@
 
 from __future__ import absolute_import
 
-from .enums import SheetFilterType
 from ..types import *
 from ..util import serialize
 from ..util import deserialize
@@ -32,17 +31,31 @@ class SheetForm(object):
         self._base = None
         if base_obj is not None:
             self._base = base_obj
-            self._id = Number()
-            self._publish_type = String()
-            self._publish_key = String()
-            self._publish_url = String()
-            self._title = String()
-            self._published = Boolean()
+        
+        self._id = Number()
+        self._publish_type = String()
+        self._publish_key = String()
+        self._publish_url = String()
+        self._title = String()
+        self._published = Boolean()
 
         if props:
             deserialize(self, props)
 
         self.request_response = None
+        self.__initialized = True
+
+    # def __getattr__(self, key):
+    #     if key == 'id':
+    #         return self.id_
+    #     else:
+    #         raise AttributeError(key)
+
+    # def __setattr__(self, key, value):
+    #     if key == 'id':
+    #         self.id_ = value
+    #     else:
+    #         super(SheetForm, self).__setattr__(key, value)
 
     @property
     def id(self):

--- a/smartsheet/models/sheet_form.py
+++ b/smartsheet/models/sheet_form.py
@@ -1,0 +1,103 @@
+# pylint: disable=C0111,R0902,R0904,R0912,R0913,R0915,E1101
+# Smartsheet Python SDK.
+#
+# Copyright 2017 Smartsheet.com, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"): you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from __future__ import absolute_import
+
+from .enums import SheetFilterType
+from ..types import *
+from ..util import serialize
+from ..util import deserialize
+
+
+class SheetForm(object):
+
+    """Smartsheet SheetForm data model."""
+
+    def __init__(self, props=None, base_obj=None):
+        """Initialize the SheetForm model."""
+        self._base = None
+        if base_obj is not None:
+            self._base = base_obj
+            self._id = Number()
+            self._publish_type = String()
+            self._publish_key = String()
+            self._publish_url = String()
+            self._title = String()
+            self._published = Boolean()
+
+        if props:
+            deserialize(self, props)
+
+        self.request_response = None
+
+    @property
+    def id(self):
+        return self._id
+
+    @id.setter
+    def id(self, value):
+        self._id.value = value
+
+    @property
+    def publish_type(self):
+        return self._publish_type.value
+
+    @publish_type.setter
+    def publish_type(self, value):
+        self._publish_type.value = value
+
+    @property
+    def publish_key(self):
+        return self._publish_key.value
+
+    @publish_key.setter
+    def publish_key(self, value):
+        self._publish_key.value = value
+
+    @property
+    def publish_url(self):
+        return self._publish_url
+
+    @publish_url.setter
+    def publish_url(self, value):
+        self._publish_url.value = value
+    
+    @property
+    def title(self):
+        return self._title
+    
+    @title.setter
+    def title(self, value):
+        self._title.value = value
+
+    @property
+    def published(self):
+        return self._published
+
+    @published.setter
+    def published(self, value):
+        self._published.value = value
+
+    def to_dict(self):
+        return serialize(self)
+
+    def to_json(self):
+        return json.dumps(self.to_dict())
+
+    def __str__(self):
+        return self.to_json()
+        


### PR DESCRIPTION
Added a new "SheetForm" model, as well as a forms attribute to the Sheet model. This creates support for `include='publishedFormContainers'` when doing a get_sheet operation.