### PR TITLE
Fix for import error of MutableSequence in Python3.10.2

### DIFF
--- a/smartsheet/types.py
+++ b/smartsheet/types.py
@@ -25,8 +25,12 @@ from datetime import datetime
 from dateutil.parser import parse
 from enum import Enum
 
+try:
+    from collections import MutableSequence
+except ImportError:
+    from collections.abc import MutableSequence
 
-class TypedList(collections.MutableSequence):
+class TypedList(MutableSequence):
 
     def __init__(self, item_type):
         self.item_type = item_type


### PR DESCRIPTION
Its now moved to `collections.abc.MutableSequence`