### PR TITLE
Avoid DeprecationWarning of collections.abc if possible

### DIFF
--- a/smartsheet/types.py
+++ b/smartsheet/types.py
@@ -16,11 +16,11 @@
 # under the License.
 
 try:
-    # For Python versions 2.7 and 3.3 to 3.9, import from collections
-    from collections import MutableSequence
-except ImportError:
     # For Python version >= 3.10 import from collections.abc
     from collections.abc import MutableSequence
+except ImportError:
+    # For Python versions 2.7 and 3.3 to 3.9, import from collections
+    from collections import MutableSequence
 
 import importlib
 import json


### PR DESCRIPTION
Why not the other way around, right?

![Selection_707](https://user-images.githubusercontent.com/25005517/209167156-090e7d34-71f6-4623-bff3-6af9eb10c231.png)
